### PR TITLE
Add support for Literate CoffeeScript

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -10,7 +10,7 @@ module.exports = (env, callback) ->
     constructor: (@_filepath, @_text) ->
 
     getFilename: ->
-      @_filepath.relative.replace /(coffee|litcoffee|coffee.md)$/, 'js'
+      @_filepath.relative.replace /(coffee|litcoffee|coffee\.md)$/, 'js'
     
     getView: ->
       return (env, locals, contents, templates, callback) ->     
@@ -28,7 +28,5 @@ module.exports = (env, callback) ->
       else
         callback null, new CoffeePlugin filepath, buffer.toString()
 
-  env.registerContentPlugin 'coffee', '**/*.coffee', CoffeePlugin
-  env.registerContentPlugin 'coffee', '**/*.litcoffee', CoffeePlugin
-  env.registerContentPlugin 'coffee', '**/*.coffee.md', CoffeePlugin
+  env.registerContentPlugin 'coffee', '**/*.*(coffee|litcoffee|coffee.md)', CoffeePlugin
   callback()


### PR DESCRIPTION
Added support for `*.litcoffee` and `.coffee.md`. Using CoffeeScript's built in `isLiterate()` helper to determine if `literate` option should be passed.

Tried using:

```
env.registerContentPlugin 'coffee', '**/*.(coffee|litcoffee|coffee.md)', CoffeePlugin
```

... but it didn't seem to honor it, so instead registered the content plugin once per extension. 

Would love to see this make it in, let me know if you'd like anything different!
