### PR TITLE
Update plugin.coffee

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -11,9 +11,9 @@ module.exports = (env, callback) ->
       @_filepath.relative.replace /(coffee|litcoffee|coffee\.md)$/, 'js'
 
     getView: ->
-      return (env, locals, contents, templates, callback) ->     
+      return (env, locals, contents, templates, callback) ->
         try
-          js = CoffeeScript.compile @_text, 
+          js = CoffeeScript.compile @_text,
             literate: CoffeeScript.helpers.isLiterate @_filepath.full
           callback null, new Buffer js
         catch error

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -7,11 +7,9 @@ module.exports = (env, callback) ->
 
   class CoffeePlugin extends env.ContentPlugin
 
-    constructor: (@_filepath, @_text) ->
-
     getFilename: ->
       @_filepath.relative.replace /(coffee|litcoffee|coffee\.md)$/, 'js'
-    
+
     getView: ->
       return (env, locals, contents, templates, callback) ->     
         try


### PR DESCRIPTION
Fixes compilation issues on later versions of the compiler.

Current version of the file raises the following error:
```
[stdin]:10:19: error: Can't use @params in derived class constructors without calling super
    constructor: (@_filepath, @_text) ->
                  ^^^^^^^^^^
```

Also removed some trailing whitespace